### PR TITLE
・レイキャストの探索処理分岐調整

### DIFF
--- a/Assets/Scenes/SearcTest.unity
+++ b/Assets/Scenes/SearcTest.unity
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 432518383}
   - component: {fileID: 432518382}
   - component: {fileID: 432518381}
+  - component: {fileID: 432518385}
   - component: {fileID: 432518384}
   m_Layer: 0
   m_Name: Cube_Player
@@ -152,7 +153,7 @@ Transform:
   m_GameObject: {fileID: 432518379}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.61, y: 0.69052446, z: 4.18}
+  m_LocalPosition: {x: 6.09, y: 0.69052446, z: 4.31}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -246,6 +247,33 @@ MonoBehaviour:
   m_processIntervalTime: 1
   m_playerNodeObj: {fileID: 0}
   m_lastPlayerNode: {fileID: 0}
+--- !u!54 &432518385
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 432518379}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
 --- !u!1 &479461015
 GameObject:
   m_ObjectHideFlags: 0
@@ -1053,7 +1081,7 @@ Transform:
   m_GameObject: {fileID: 1234216156}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.3, y: -0.4107027, z: 2.08}
+  m_LocalPosition: {x: 1.3, y: -0.21, z: 2.08}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1357,6 +1385,7 @@ GameObject:
   - component: {fileID: 1545320663}
   - component: {fileID: 1545320662}
   - component: {fileID: 1545320661}
+  - component: {fileID: 1545320665}
   m_Layer: 0
   m_Name: Cube_Wall
   m_TagString: Wall
@@ -1450,6 +1479,33 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &1545320665
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1545320660}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &1699185406
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Temporary/hiramaTemporary/Scripte/Enemy.cs
+++ b/Assets/Temporary/hiramaTemporary/Scripte/Enemy.cs
@@ -37,6 +37,7 @@ public class Enemy : MonoBehaviour
             ClearShortestRoute();             //前回最短経路初期化
             Node nodeObject = GetFirstPos();  //初回地点取得
             GetShortestRoute(nodeObject);     //最短経路ルート取得
+
             //Debug.Log("最短経路：" + string.Join(", ", m_shortNodeObjList) + m_shortNodePosDis);
 
             yield return new WaitForSeconds(m_processIntervalTime);
@@ -65,7 +66,11 @@ public class Enemy : MonoBehaviour
             //プレイヤーを視認した場合、
             if (hit.collider.CompareTag("Player"))
             {
-                Debug.Log("プレイヤー判定");
+                //プレイヤーから最も近い経由地点を取得
+                GameObject playerNodeObj = GameObject.FindWithTag("Player");
+                firstNodeObj = playerNodeObj.GetComponent<Player>().m_playerNodeObj;
+
+                //Debug.Log("プレイヤー判定");
             }
             //プレイヤーを視認できなかった場合、
             else
@@ -100,7 +105,8 @@ public class Enemy : MonoBehaviour
 
                 //自身から最も近い経由地点を取得
                 firstNodeObj = m_firstNodePosList[firstNodeNumMin].nodeObj.GetComponent<Node>();
-                Debug.Log("障害物判定");
+
+                //Debug.Log("障害物判定");
             }
         }
 

--- a/Assets/Temporary/hiramaTemporary/Scripte/Player.cs
+++ b/Assets/Temporary/hiramaTemporary/Scripte/Player.cs
@@ -74,6 +74,7 @@ public class Player : MonoBehaviour
             {
                 m_playerNodeObj.m_isPlayer = true;
                 m_lastPlayerNode = m_playerNodeObj;
+
                 //Debug.Log("プレイヤー最寄経由地点：" + playerNodeObj);
             }
 

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 14
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -18,10 +19,12 @@ PhysicsManager:
   m_ClothInterCollisionStiffness: 0
   m_ContactsGeneration: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
+  m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
   m_BroadphaseType: 0
   m_WorldBounds:
@@ -31,4 +34,6 @@ PhysicsManager:
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
   m_EnableUnifiedHeightmaps: 1
-  m_DefaultMaxAngluarSpeed: 7
+  m_ImprovedPatchFriction: 0
+  m_SolverType: 0
+  m_DefaultMaxAngularSpeed: 7


### PR DESCRIPTION
→プレイヤー座標ではなく、プレイヤー最寄座標の移動に変更
→壁の当たり判定やノードの位置など、テストシーンの造形を変更